### PR TITLE
抽象出从地址空间访问的组件

### DIFF
--- a/src/main/scala/AddressSpace.scala
+++ b/src/main/scala/AddressSpace.scala
@@ -1,0 +1,52 @@
+import chisel3._
+import chisel3.util._
+
+// This is an abstraction among
+// interfaces of controllers which can accessed
+// like a memory, eg. SRAM, CSR and IO
+class AddressIOInterface extends Bundle {
+  val read_mode = Input(Bool())
+  val addr = Input(UInt(32.W))
+  val maskLevel = Input(UInt(2.W))
+  val dataIn = Input(UInt(32.W))
+  val dataOut = Output(UInt(32.W))
+}
+
+class AddressSpace extends Module {
+  val io = IO(new AddressIOInterface {
+    val gpioOut = Output(UInt(32.W))
+  })
+  val sram = Module(new ByteAddressedSRAM)
+  val gpio = Module(new GPIOController)
+  // todo: consider make all submodules only take the low 30 bits, then we can use `<>` here
+  sram.io.read_mode := true.B
+  sram.io.addr := 0.U(32.W)
+  sram.io.dataIn := 0.U(32.W)
+  sram.io.maskLevel := Mask.NONE
+
+  gpio.io.read_mode := true.B
+  gpio.io.addr := 0.U(32.W)
+  gpio.io.dataIn := 0.U(32.W)
+  gpio.io.maskLevel := Mask.NONE
+
+  io.dataOut := 0xdead.U(32.W)
+  io.gpioOut := gpio.io.dataOut
+
+  switch(io.addr(31, 30)) {
+    is("b00".U) {
+      sram.io.dataIn := io.dataIn
+      sram.io.addr := io.addr
+      sram.io.maskLevel := io.maskLevel
+      sram.io.read_mode := io.read_mode
+      io.dataOut := sram.io.dataOut
+    }
+    is("b01".U) {
+      gpio.io.dataIn := io.dataIn
+      gpio.io.addr := Cat("b00".U, io.addr(29, 0))
+      gpio.io.maskLevel := io.maskLevel
+      gpio.io.read_mode := io.read_mode
+      io.dataOut := gpio.io.dataOut
+    }
+    // others are reserved for CSRs, etc
+  }
+}

--- a/src/main/scala/GPIOController.scala
+++ b/src/main/scala/GPIOController.scala
@@ -1,0 +1,14 @@
+import chisel3._
+
+// A GPIO Controller
+// Currently this is for test only,
+// a 32-bit register is directly mapped to 32 read-only ports
+// todo: consider a better way of handling GPIO
+class GPIOController extends Module {
+  val io = IO(new AddressIOInterface)
+  val current_value = RegInit(0.U(32.W))
+  io.dataOut := current_value
+  when(io.maskLevel =/= Mask.NONE) {
+    current_value := io.dataIn
+  }
+}

--- a/src/main/scala/SRAM.scala
+++ b/src/main/scala/SRAM.scala
@@ -24,13 +24,7 @@ class ByteAddressedSRAM extends Module {
 
   import Mask._
 
-  val io = IO(new Bundle {
-    val read_mode = Input(Bool())
-    val addr = Input(UInt(12.W))
-    val maskLevel = Input(UInt(2.W))
-    val dataIn = Input(UInt(32.W))
-    val dataOut = Output(UInt(32.W))
-  })
+  val io = IO(new AddressIOInterface)
 
   val inner = Module(new SRAM)
   inner.io.enable := io.read_mode

--- a/src/test/scala/AddressSpaceTest.scala
+++ b/src/test/scala/AddressSpaceTest.scala
@@ -1,0 +1,44 @@
+import chisel3._
+import chisel3.iotesters._
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class AddressIOTest(addressSpace: AddressSpace) extends PeekPokeTester(addressSpace) {
+
+  import Mask._
+
+  val cases = Array(
+    (false.B, 0.U(32.W), WORD, "hd8c7b6a5".U(32.W), "0", "0"),
+    (true.B, 0.U(32.W), WORD, "h00000000".U(32.W), "hd8c7b6a5", "0"),
+
+    (false.B, "h40000000".U(32.W), WORD, "hd8c7b6a5".U(32.W), "0", "0"),
+    (true.B, 0.U(32.W), WORD, "h00000000".U(32.W), "hd8c7b6a5", "hd8c7b6a5"),
+  )
+  for ((enable_read, address, maskLevel, dataIn, expectedDataOut, expectedGPIOOut) <- cases) {
+    poke(addressSpace.io.read_mode, enable_read)
+    poke(addressSpace.io.addr, address)
+    poke(addressSpace.io.maskLevel, maskLevel)
+    poke(addressSpace.io.dataIn, dataIn)
+
+    step(1)
+
+    if (expectedDataOut != "0") {
+      expect(addressSpace.io.dataOut, expectedDataOut.U)
+    }
+    if (expectedGPIOOut != "0") {
+      expect(addressSpace.io.gpioOut, expectedGPIOOut.U)
+    }
+  }
+}
+
+class AddressedIOSpec extends FlatSpec with Matchers {
+  behavior of "AddressedIOSpec"
+
+
+  it should "read and write successfully" in {
+    chisel3.iotesters.Driver.execute(Array("--generate-vcd-output", "on"), () => new AddressSpace) { sram =>
+      new AddressIOTest(sram)
+    } should be(true)
+  }
+}
+


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

包括GPIO、CSR、SRAM及未来可能的DRAM都是通过统一的地址空间去访问的，所以可以抽象出一个统一的接口，并由一个组件负责分配某个地址到底链接到哪个组件
顺便添加一个测试用的GPIO控制器，这个控制器在发布版本中如何设计还需讨论