### PR TITLE
Manually extend zero for LOADING Byte/Half Word.

### DIFF
--- a/src/main/scala/CPU.scala
+++ b/src/main/scala/CPU.scala
@@ -13,6 +13,7 @@ class CPU extends Module {
 
   val io = IO(new CPUBundle)
 
+  // inherit from BSD*.
   val pc = RegInit("h80000000".U(32.W))
   pc := pc + 4.U
   io.programROMBundle.address := pc
@@ -61,20 +62,25 @@ class CPU extends Module {
     io.dataBusBundle.maskLevel := instruction(13, 12)
     // second part of load
     switch(instruction(14, 12)) {
+      // LB
       is("b000".U) {
         regFile.io.input := io.dataBusBundle.dataOut(7, 0)
       }
+      // LH
       is("b001".U) {
         regFile.io.input := io.dataBusBundle.dataOut(15, 0)
       }
+      // LW
       is("b010".U) {
         regFile.io.input := io.dataBusBundle.dataOut
       }
+      // LBU
       is("b100".U) {
-        regFile.io.input := io.dataBusBundle.dataOut
+        regFile.io.input := io.dataBusBundle.dataOut(7, 0).asUInt()
       }
+      // LHU
       is("b101".U) {
-        regFile.io.input := io.dataBusBundle.dataOut
+        regFile.io.input := io.dataBusBundle.dataOut(15, 0).asUInt()
       }
     }
   }.elsewhen(csr.io.interruptPending) {

--- a/src/main/scala/SRAM.scala
+++ b/src/main/scala/SRAM.scala
@@ -3,6 +3,7 @@ import chisel3.util._
 
 // An sram
 // @see https://www.chisel-lang.org/chisel3/memories.html
+// @see https://github.com/ucb-bar/chisel-tutorial/wiki/Conditional-Assignments-and-Memories
 class SRAM extends Module {
   val io = IO(new Bundle {
     val enable = Input(Bool())


### PR DESCRIPTION
Affects LBU, LHU.

### What problem does this PR solve?

Summary:

fix LBU, LHU

What's Changed:

LBU, LHU from address of 0xff in 0x0000ff00 will get 0x000000ff and 0x0000ff00 instead of 0xffffffff and 0xffffff00.