### PR TITLE
CPU: fix CALCULATE_IMM op bug

### DIFF
--- a/src/main/scala/CPU.scala
+++ b/src/main/scala/CPU.scala
@@ -13,7 +13,7 @@ class CPU extends Module {
 
   val io = IO(new CPUBundle)
 
-  // inherit from BSD*.
+  // start up address here are from BSD's CPU
   val pc = RegInit("h80000000".U(32.W))
   pc := pc + 4.U
   io.programROMBundle.address := pc
@@ -144,7 +144,11 @@ class CPU extends Module {
         regFile.io.writeEnable := true.B
         alu.io.A := regFile.io.outputA
         alu.io.B := immGen.io.result.asUInt()
-        alu.io.op := Cat(instruction(30), instruction(14, 12))
+        when(instruction(14, 12) === "b001".U || instruction(14, 12) === "b101".U) {
+          alu.io.op := Cat(instruction(30), instruction(14, 12))
+        }.otherwise {
+          alu.io.op := Cat(0.U(1.W), instruction(14, 12))
+        }
         regFile.io.input := alu.io.result
       }
       is(CALCULATE_REG) {


### PR DESCRIPTION
<!-- Thank you for contributing to shuorv!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #44 

Problem Summary:

CALCULATE_IMM's op is not calculated correctly

### What is changed and how it works?

How it Works:

Just concat with `instruction(30)` when necessary.


